### PR TITLE
Better support for tagged unions

### DIFF
--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -69,6 +69,50 @@ test('union of interfaces', (t) => {
   ])
 })
 
+test('tagged unions', (t) => {
+  const UnionOfInterfaces = iots.union([
+    iots.interface({_tag: iots.literal('key'), key: iots.string}),
+    iots.interface({_tag: iots.literal('code'), code: iots.number}),
+  ])
+  const WithUnion = iots.interface({data: UnionOfInterfaces})
+
+  t.deepEqual(Reporter.report(WithUnion.decode({})), [
+    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: undefined',
+  ])
+
+  t.deepEqual(Reporter.report(WithUnion.decode({data: ''})), [
+    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: ""',
+  ])
+
+  t.deepEqual(Reporter.report(WithUnion.decode({data: {}})), [
+    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: {}',
+  ])
+
+  t.deepEqual(Reporter.report(WithUnion.decode({data: {code: '123'}})), [
+    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: {"code":"123"}',
+  ])
+
+  t.deepEqual(
+    Reporter.report(
+      WithUnion.decode({
+        data: {_tag: 'bogus', code: '123'},
+      }),
+    ),
+    [
+      'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: {"_tag":"bogus","code":"123"}',
+    ],
+  )
+
+  t.deepEqual(
+    Reporter.report(
+      WithUnion.decode({
+        data: {_tag: 'code', code: '123'},
+      }),
+    ),
+    ['Expecting number at data but instead got: "123"'],
+  )
+})
+
 const Gender = iots.union([
   iots.literal('Male'),
   iots.literal('Female'),

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -77,19 +77,35 @@ test('tagged unions', (t) => {
   const WithUnion = iots.interface({data: UnionOfInterfaces})
 
   t.deepEqual(Reporter.report(WithUnion.decode({})), [
-    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: undefined',
+    [
+      'Expecting one of:',
+      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      'at data but instead got: undefined',
+    ].join('\n'),
   ])
 
   t.deepEqual(Reporter.report(WithUnion.decode({data: ''})), [
-    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: ""',
+    [
+      'Expecting one of:',
+      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      'at data but instead got: ""',
+    ].join('\n'),
   ])
 
   t.deepEqual(Reporter.report(WithUnion.decode({data: {}})), [
-    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: {}',
+    [
+      'Expecting one of:',
+      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      'at data but instead got: {}',
+    ].join('\n'),
   ])
 
   t.deepEqual(Reporter.report(WithUnion.decode({data: {code: '123'}})), [
-    'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: {"code":"123"}',
+    [
+      'Expecting one of:',
+      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      'at data but instead got: {"code":"123"}',
+    ].join('\n'),
   ])
 
   t.deepEqual(
@@ -99,7 +115,11 @@ test('tagged unions', (t) => {
       }),
     ),
     [
-      'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: {"_tag":"bogus","code":"123"}',
+      [
+        'Expecting one of:',
+        '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+        'at data but instead got: {"_tag":"bogus","code":"123"}',
+      ].join('\n'),
     ],
   )
 
@@ -109,7 +129,13 @@ test('tagged unions', (t) => {
         data: {_tag: 'code', code: '123'},
       }),
     ),
-    ['Expecting number at data but instead got: "123"'],
+    [
+      [
+        'Expecting one of:',
+        '    { _tag: "code", code: number }',
+        'at data but instead got: {"_tag":"code","code":"123"}',
+      ].join('\n'),
+    ],
   )
 })
 

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -79,7 +79,8 @@ test('tagged unions', (t) => {
   t.deepEqual(Reporter.report(WithUnion.decode({})), [
     [
       'Expecting one of:',
-      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      '    { _tag: "key", key: string }',
+      '    { _tag: "code", code: number }',
       'at data but instead got: undefined',
     ].join('\n'),
   ])
@@ -87,7 +88,8 @@ test('tagged unions', (t) => {
   t.deepEqual(Reporter.report(WithUnion.decode({data: ''})), [
     [
       'Expecting one of:',
-      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      '    { _tag: "key", key: string }',
+      '    { _tag: "code", code: number }',
       'at data but instead got: ""',
     ].join('\n'),
   ])
@@ -95,7 +97,8 @@ test('tagged unions', (t) => {
   t.deepEqual(Reporter.report(WithUnion.decode({data: {}})), [
     [
       'Expecting one of:',
-      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      '    { _tag: "key", key: string }',
+      '    { _tag: "code", code: number }',
       'at data but instead got: {}',
     ].join('\n'),
   ])
@@ -103,7 +106,8 @@ test('tagged unions', (t) => {
   t.deepEqual(Reporter.report(WithUnion.decode({data: {code: '123'}})), [
     [
       'Expecting one of:',
-      '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+      '    { _tag: "key", key: string }',
+      '    { _tag: "code", code: number }',
       'at data but instead got: {"code":"123"}',
     ].join('\n'),
   ])
@@ -117,7 +121,8 @@ test('tagged unions', (t) => {
     [
       [
         'Expecting one of:',
-        '    ({ _tag: "key", key: string } | { _tag: "code", code: number })',
+        '    { _tag: "key", key: string }',
+        '    { _tag: "code", code: number }',
         'at data but instead got: {"_tag":"bogus","code":"123"}',
       ].join('\n'),
     ],
@@ -129,13 +134,7 @@ test('tagged unions', (t) => {
         data: {_tag: 'code', code: '123'},
       }),
     ),
-    [
-      [
-        'Expecting one of:',
-        '    { _tag: "code", code: number }',
-        'at data but instead got: {"_tag":"code","code":"123"}',
-      ].join('\n'),
-    ],
+    [['Expecting number at data.code but instead got: "123"'].join('\n')],
   )
 })
 


### PR DESCRIPTION
Hello,

please consider this change. It adds a bit of fine tuning for tagged unions, especially in the case where the discriminating property is present and valid, but the rest of the object is not. Compare the changes between my two commits to see what I mean, particularly in the last assertion:

Before:

```typescript
t.deepEqual(
  Reporter.report(
    WithUnion.decode({
      data: {_tag: 'code', code: '123'},
    }),
  ),
  ['Expecting number at data but instead got: "123"'],
)


t.deepEqual(Reporter.report(WithUnion.decode({data: {code: '123'}})), [
  'Expecting ({ _tag: "key", key: string } | { _tag: "code", code: number }) at data but instead got: {"code":"123"}',
])
```

After:

```typescript
t.deepEqual(
  Reporter.report(
    WithUnion.decode({
      data: {_tag: 'code', code: '123'},
    }),
  ),
  [['Expecting number at data.code but instead got: "123"'].join('\n')],
)

t.deepEqual(Reporter.report(WithUnion.decode({data: {code: '123'}})), [
  [
    'Expecting one of:',
    '    { _tag: "key", key: string }',
    '    { _tag: "code", code: number }',
    'at data but instead got: {"code":"123"}',
  ].join('\n'),
])
```